### PR TITLE
Fix WP6.7 _load_textdomain_just_in_time warning

### DIFF
--- a/panels/class-debug-bar-wp-http.php
+++ b/panels/class-debug-bar-wp-http.php
@@ -69,7 +69,7 @@ class Debug_Bar_WP_Http extends Debug_Bar_Panel {
 	}
 
 	function init() {
-		$this->title( __( 'WP_Http', 'debug-bar' ) );
+		$this->title( 'WP_Http' );
 	}
 
 	function prerender() {


### PR DESCRIPTION
[Because `Debug_Bar_WP_Http` is initialized early](https://github.com/WordPress/debug-bar/blob/23b15fc11f41ec816fd1a1a4805bcbd518173b39/debug-bar.php#L46), this calls a translation function too early which causes [the new 6.7 warning to be triggered](https://make.wordpress.org/core/2024/10/21/i18n-improvements-6-7/):

```
#0 wp-includes/l10n.php(1386): _load_textdomain_just_in_time('debug-bar')
#1 wp-includes/l10n.php(194): get_translations_for_domain('debug-bar')
#2 wp-includes/l10n.php(306): translate('WP_Http', 'debug-bar')
#3 wp-content/plugins/debug-bar/panels/class-debug-bar-wp-http.php(72): __('WP_Http', 'debug-bar')
#4 wp-content/plugins/debug-bar/panels/class-debug-bar-panel.php(10): Debug_Bar_WP_Http->init()
#5 wp-content/plugins/debug-bar/debug-bar.php(46): Debug_Bar_Panel->__construct()
#6 wp-content/plugins/debug-bar/debug-bar.php(393): Debug_Bar->early_init()
#7 wp-settings.php(526): include_once('wp-content/plugi...')
#8 wp-config.php(232): require_once('wp-content/plugi...')
#9 wp-load.php(50): require_once('wp-content/plugi...')
#10 wp-blog-header.php(13): require_once('wp-content/plugi...')
#11 index.php(17): require('wp-content/plugi...')
```