### PR TITLE
fixed : WordPress.Security.EscapeOutput.OutputNotEscaped

### DIFF
--- a/debug-bar.php
+++ b/debug-bar.php
@@ -177,7 +177,7 @@ class Debug_Bar {
 	function ensure_ajaxurl() { ?>
 		<script type="text/javascript">
 			//<![CDATA[
-			var ajaxurl = '<?php echo admin_url( 'admin-ajax.php' ); ?>';
+			var ajaxurl = '<?php echo esc_url( admin_url( 'admin-ajax.php' ) ); ?>';
 			//]]>
 		</script>
 		<?php


### PR DESCRIPTION
fixed : WordPress.Security.EscapeOutput.OutputNotEscaped
- All output should be run through an escaping function (see the Security sections in the WordPress Developer Handbooks), found 'admin_url'.