### PR TITLE
issue/17 - Error Handler: Remove `E_STRICT` usage.

### DIFF
--- a/panels/class-debug-bar-php.php
+++ b/panels/class-debug-bar-php.php
@@ -56,9 +56,6 @@ class Debug_Bar_PHP extends Debug_Bar_Panel {
 					wp_debug_backtrace_summary( __CLASS__ ),
 				);
 				break;
-			case E_STRICT:
-				// TODO
-				break;
 			case E_DEPRECATED:
 			case E_USER_DEPRECATED:
 				// TODO


### PR DESCRIPTION
Deprecated in PHP 8.4, this constant was not being used so it can safely be removed without causing any breakage.

Fixes #17.